### PR TITLE
feat: centralized configuration directory support (v0.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ gh-self-runner-cli init
 
 You'll be prompted for:
 - Repository URL (e.g., `owner/repo` or `https://github.com/owner/repo`)
+- Configuration directory (default: `~/.config/gh-self-runner-cli`)
 - Authentication method (GitHub CLI or Personal Access Token)
 - Number of runners to create (default: 1)
 
@@ -159,12 +160,15 @@ Simply run `stop` followed by `start` to restart your runners.
 ### Want to remove everything?
 The `clean` command removes all configurations and runners.
 
+### Where are configurations stored?
+By default, configurations are stored in `~/.config/gh-self-runner-cli`. You can override this with the `GH_SELF_RUNNER_CONFIG_DIR` environment variable.
+
 ## Troubleshooting
 
 ### Runners won't start
 1. Verify your GitHub authentication is valid
 2. Check if self-hosted runners are enabled in your repository settings
-3. Review the log files in `.github/self-hosted-runners/runners/`
+3. Review the log files in your configuration directory
 4. Run with debug mode: `DEBUG=* gh-self-runner-cli start`
 
 ### Permission errors

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No changes yet_
 
+## [0.2.0] - 2025-06-28
+
+### ⚠️ BREAKING CHANGES
+
+- Configuration files are now stored in a centralized directory (`~/.config/gh-self-runner-cli` by default) instead of the current working directory
+- The `.github/self-hosted-runners` directory is no longer created in the current working directory
+
+### ✨ Features
+
+#### Configuration Management
+- **Centralized Configuration**: Configuration files are now stored in `~/.config/gh-self-runner-cli` by default
+- **Custom Config Directory**: Users can specify a custom configuration directory during `init`
+- **Environment Variable Support**: Set `GH_SELF_RUNNER_CONFIG_DIR` to override the default location
+- **Repository Reference**: A `.github-self-runner-config` file is created in the repository to reference the configuration location
+
+### 🔄 Changes
+
+- Configuration is now stored outside of the repository by default to reduce noise
+- The init command now prompts for the configuration directory location
+- All commands now use the centralized configuration directory
+- The `.github-self-runner-config` reference file is automatically added to `.gitignore`
+
+### 📋 Migration Guide
+
+For users upgrading from v0.1.0:
+
+1. Run `gh-self-runner-cli init` in your repository
+2. Choose a configuration directory (default: `~/.config/gh-self-runner-cli`)
+3. Your configuration will be stored in the chosen directory
+4. A reference file will be created at `.github-self-runner-config`
+
+[0.2.0]: https://github.com/shota-higaki/gh-self-runner-cli/releases/tag/v0.2.0
+
 ## [0.1.0] - 2025-06-27
 
 ### 🎉 Initial Release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-self-runner-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Dynamic GitHub Self-Hosted Runners management tool",
   "type": "module",
   "author": "Shota Higaki <shota-higaki@users.noreply.github.com>",

--- a/src/utils/config-directory.ts
+++ b/src/utils/config-directory.ts
@@ -1,0 +1,57 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Get the default configuration directory
+ * Defaults to ~/.config/gh-self-runner-cli
+ */
+export function getDefaultConfigDirectory(): string {
+  return join(homedir(), '.config', 'gh-self-runner-cli');
+}
+
+/**
+ * Get the configuration directory from environment or default
+ */
+export function getConfigDirectory(): string {
+  return process.env.GH_SELF_RUNNER_CONFIG_DIR || getDefaultConfigDirectory();
+}
+
+/**
+ * Ensure the configuration directory exists
+ */
+export function ensureConfigDirectory(configDir: string): void {
+  if (!existsSync(configDir)) {
+    mkdirSync(configDir, { recursive: true });
+  }
+}
+
+/**
+ * Store the selected config directory in a marker file in the current directory
+ */
+export function storeConfigDirectoryReference(configDir: string): void {
+  const markerPath = join(process.cwd(), '.github-self-runner-config');
+  const content = `# GitHub Self-Hosted Runner CLI Configuration\n# This file indicates that this repository uses gh-self-runner-cli\n# Configuration directory: ${configDir}\nconfig_directory: ${configDir}\n`;
+
+  // Write the marker file
+  writeFileSync(markerPath, content, 'utf-8');
+}
+
+/**
+ * Read the config directory reference from the marker file
+ */
+export function readConfigDirectoryReference(): string | null {
+  const markerPath = join(process.cwd(), '.github-self-runner-config');
+
+  if (!existsSync(markerPath)) {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(markerPath, 'utf-8');
+    const match = content.match(/^config_directory:\s*(.+)$/m);
+    return match && match[1] ? match[1].trim() : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,14 +1,34 @@
 import path from 'path';
+import { getConfigDirectory, readConfigDirectoryReference } from './config-directory.js';
+
+/**
+ * Get the base directory for configuration
+ * First checks for a local reference file, then uses the global config directory
+ */
+export function getBaseDirectory(): string {
+  // Check if there's a local reference to a config directory
+  const referencedDir = readConfigDirectoryReference();
+  if (referencedDir) {
+    return referencedDir;
+  }
+
+  // Otherwise use the global config directory
+  return getConfigDirectory();
+}
 
 /**
  * Path constants for the GitHub self-hosted runners
  */
 export const PATHS = {
   // Base directory for all runner-related files
-  BASE_DIR: '.github/self-hosted-runners',
+  get BASE_DIR() {
+    return getBaseDirectory();
+  },
 
   // Configuration file
-  CONFIG_FILE: '.github/self-hosted-runners/config.yml',
+  get CONFIG_FILE() {
+    return path.join(this.BASE_DIR, 'config.yml');
+  },
 
   // Old paths (for migration)
   OLD_RUNNERS_DIR: '.runners',
@@ -19,7 +39,7 @@ export const PATHS = {
  * Get the runner directory path for a specific repository
  */
 export function getRunnerRepoDir(owner: string, repo: string): string {
-  return path.resolve(process.cwd(), PATHS.BASE_DIR, 'runners', `${owner}-${repo}`);
+  return path.resolve(PATHS.BASE_DIR, 'runners', `${owner}-${repo}`);
 }
 
 /**

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -45,7 +45,7 @@ describe('CLI Integration Tests', () => {
         const execError = error as { stdout?: string; stderr?: string };
         output = execError.stdout || execError.stderr || '';
       }
-      expect(output).toContain('0.1.0');
+      expect(output).toContain('0.2.0');
     });
   });
 

--- a/tests/unit/lib/config/config-loader.test.ts
+++ b/tests/unit/lib/config/config-loader.test.ts
@@ -370,15 +370,16 @@ describe('ConfigLoader', () => {
 
   describe('cosmiconfig integration', () => {
     it('should configure cosmiconfig with correct search places', () => {
-      expect(cosmiconfig).toHaveBeenCalledWith('github-runners', {
-        searchPlaces: expect.arrayContaining([
-          '.github/self-hosted-runners/config.yml',
-          '.github-runners.yml',
-        ]),
-        loaders: expect.objectContaining({
-          '.yml': expect.any(Function),
-          '.yaml': expect.any(Function),
-        }),
+      // The first searchPlace is now dynamic based on config directory
+      // So we check that it includes 'config.yml' and the legacy path
+      const call = vi.mocked(cosmiconfig).mock.calls[0];
+      expect(call[0]).toBe('github-runners');
+      expect(call[1]?.searchPlaces).toHaveLength(2);
+      expect(call[1]?.searchPlaces[0]).toMatch(/config\.yml$/);
+      expect(call[1]?.searchPlaces[1]).toBe('.github-runners.yml');
+      expect(call[1]?.loaders).toMatchObject({
+        '.yml': expect.any(Function),
+        '.yaml': expect.any(Function),
       });
     });
   });


### PR DESCRIPTION
## Summary
- Configuration files are now stored in a centralized directory instead of the current working directory
- Default location: `~/.config/gh-self-runner-cli`
- Users can specify custom directory during `init` command
- Environment variable `GH_SELF_RUNNER_CONFIG_DIR` can override the default

## Breaking Changes
- The `.github/self-hosted-runners` directory is no longer created in the current working directory
- Configuration is now stored outside of the repository by default

## Test plan
- [ ] Run `gh-self-runner-cli init` and verify it prompts for config directory
- [ ] Verify configuration is created in the specified directory
- [ ] Verify `.github-self-runner-config` reference file is created
- [ ] Test that all commands work with the new configuration location
- [ ] Test environment variable override

🤖 Generated with [Claude Code](https://claude.ai/code)